### PR TITLE
fix: email input too long

### DIFF
--- a/web/assets/scss/_theme.scss
+++ b/web/assets/scss/_theme.scss
@@ -75,7 +75,7 @@ $input-border-width: 1px;
 $input-border-radius: 16px;
 $input-padding-y: 12px;
 $input-padding-x: 16px;
-$input-font-size: 16px;
+$input-font-size: 1.1rem;
 $input-line-height: 1.9; // Use unitless value for line-height
 $input-height: 56px;
 $input-focus-border-color: $primary;

--- a/web/assets/scss/components/_input.scss
+++ b/web/assets/scss/components/_input.scss
@@ -7,7 +7,7 @@
     + .btn {
       position: absolute;
       right: 6px;
-      top: 7px;
+      top: 8px;
       height: 42px;
       border-radius: 16px !important;
       z-index: 6;

--- a/web/index.html
+++ b/web/index.html
@@ -130,14 +130,20 @@
             <p class="lead text-muted mb-5">
               Check if your email address is in a data breach
             </p>
-            <div class="input-group mb-4">
-              <input
-                type="email"
-                class="form-control"
-                placeholder="Email address"
-                id="emailInput"
-              />
-              <button class="btn btn-primary" id="checkButton">Check</button>
+            <div class="row justify-content-center">
+              <div class="col-12 col-md-8">
+                <div class="input-group mb-4">
+                  <input
+                    type="email"
+                    class="form-control"
+                    placeholder="Email address"
+                    id="emailInput"
+                  />
+                  <button class="btn btn-primary" id="checkButton">
+                    Check
+                  </button>
+                </div>
+              </div>
             </div>
             <p class="text-muted body-small">
               Using Have I Been Pwned is subject to the


### PR DESCRIPTION
Reduced the width of the email input on the frontpage, kept it at full width on mobile devices. Increased the size of the input text to make it more readable.

Closes #17 