### PR TITLE
fix: unnecessary margin causing scrollbars to appear when they don't have to

### DIFF
--- a/web/assets/scss/_custom.scss
+++ b/web/assets/scss/_custom.scss
@@ -91,6 +91,7 @@
 
 // Background glow effect
 body {
+  padding-top: 1rem;
   &::before {
     content: "";
     position: fixed;

--- a/web/assets/scss/components/_navbar.scss
+++ b/web/assets/scss/components/_navbar.scss
@@ -2,7 +2,7 @@
 
 /* Navbar Component */
 .navbar {
-  margin: 1rem auto;
+  margin: 0 auto;
   max-width: 1140px;
   width: 95%;
   border: 1px solid rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
- Remove margin on the `.navbar` that pushed the total height of the content to exceed the viewport height which introduced the y scrollbar
- Added padding to the `body` to recreate the floating navbar effect.

Closes #21 