### PR TITLE
fix: 1password overlaying check button

### DIFF
--- a/web/assets/scss/_custom.scss
+++ b/web/assets/scss/_custom.scss
@@ -774,3 +774,35 @@ body {
     margin-bottom: 1rem;
   }
 }
+
+/* Custom Input Group Styling */
+.input-group-custom {
+  display: flex;
+  width: 100%;
+
+  .form-control {
+    flex: 1;
+    border-top-left-radius: var(--border-radius);
+    border-bottom-left-radius: var(--border-radius);
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: none;
+    padding-right: 20px;
+  }
+
+  .btn-container {
+    background-color: var(--white);
+    display: flex;
+    align-items: center;
+    border-top-right-radius: var(--border-radius);
+    border-bottom-right-radius: var(--border-radius);
+    border: 1px solid var(--bs-border-color);
+    border-left: none;
+  }
+
+  .btn {
+    height: 42px;
+    margin: 6px;
+    border-radius: var(--border-radius-sm);
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -132,16 +132,18 @@
             </p>
             <div class="row justify-content-center">
               <div class="col-12 col-md-8">
-                <div class="input-group mb-4">
+                <div class="input-group-custom mb-4">
                   <input
                     type="email"
                     class="form-control"
                     placeholder="Email address"
                     id="emailInput"
                   />
-                  <button class="btn btn-primary" id="checkButton">
-                    Check
-                  </button>
+                  <div class="btn-container">
+                    <button class="btn btn-primary" id="checkButton">
+                      Check
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Created a custom input group that puts the input and the container in adjacent elements with white background. This will put the 1password extension on the right side of the input, allowing the check button to appear as a floating input button.

![input](https://github.com/user-attachments/assets/5f0245e7-aa33-4f2d-805d-696ee4ea4274)

Closes #26 