### PR TITLE
Fix social media button gap issue and using x instead of twitter

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -639,11 +639,11 @@
               <h5 class="fw-bold mb-3">Connect With Us</h5>
               <div class="d-flex gap-3">
                 <a
-                  href="https://twitter.com/haveibeenpwned"
+                  href="https://x.com/haveibeenpwned"
                   target="_blank"
                   class="text-muted hover-white fs-5"
                 >
-                  <i class="bi bi-twitter"></i>
+                  <i class="bi bi-twitter-x"></i>
                 </a>
                 <a
                   href="https://facebook.com/haveibeenpwned"

--- a/web/pages/about.html
+++ b/web/pages/about.html
@@ -171,39 +171,38 @@
                     accessible to ensure it could be of maximum benefit to the
                     community.
                   </p>
-                  <div class="mt-4">
+                  <div class="mt-4 d-flex flex-column flex-md-row gap-2">
                     <a
-                      href="https://twitter.com/troyhunt"
+                      href="https://x.com/troyhunt"
                       target="_blank"
-                      class="btn btn-outline-primary me-2"
+                      class="btn btn-outline-primary"
                     >
-                      <i class="bi bi-twitter me-2"></i>Twitter
+                      <i class="bi bi-twitter-x"></i>
                     </a>
                     <a
                       href="https://troyhunt.com"
                       target="_blank"
-                      class="btn btn-outline-primary me-2"
+                      class="btn btn-outline-primary"
                     >
-                      <i class="bi bi-globe me-2"></i>Website
+                      <i class="bi bi-globe"></i> Website
                     </a>
                     <a
                       href="https://www.linkedin.com/in/troyhunt/"
                       target="_blank"
-                      class="btn btn-outline-primary me-2"
+                      class="btn btn-outline-primary"
                     >
-                      <i class="bi bi-linkedin me-2"></i>LinkedIn
+                      <i class="bi bi-linkedin"></i> LinkedIn
                     </a>
                     <a
                       href="https://bsky.app/profile/troyhunt.com"
                       target="_blank"
-                      class="btn btn-outline-primary me-2"
+                      class="btn btn-outline-primary"
                     >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="10 10 568 501"
                         width="16"
                         height="16"
-                        class="me-2"
                       >
                         <path
                           fill="currentColor"
@@ -217,7 +216,7 @@
                       target="_blank"
                       class="btn btn-outline-primary"
                     >
-                      <i class="bi bi-mastodon me-2"></i>Mastodon
+                      <i class="bi bi-mastodon"></i> Mastodon
                     </a>
                   </div>
                 </div>
@@ -299,32 +298,31 @@
                     reliable and sustainable and regularly shares those
                     experiences in his speaking activities.
                   </p>
-                  <div class="mt-4">
+                  <div class="mt-4 d-flex flex-column flex-md-row gap-2">
                     <a
                       href="https://x.com/stebets"
                       target="_blank"
-                      class="btn btn-outline-primary me-2"
+                      class="btn btn-outline-primary"
                     >
-                      <i class="bi bi-twitter me-2"></i>Twitter
+                      <i class="bi bi-twitter-x me-2"></i>
                     </a>
                     <a
                       href="https://www.linkedin.com/in/stebet/"
                       target="_blank"
-                      class="btn btn-outline-primary me-2"
+                      class="btn btn-outline-primary"
                     >
-                      <i class="bi bi-linkedin me-2"></i>LinkedIn
+                      <i class="bi bi-linkedin me-2"></i> LinkedIn
                     </a>
                     <a
                       href="https://bsky.app/profile/stebet.net"
                       target="_blank"
-                      class="btn btn-outline-primary me-2"
+                      class="btn btn-outline-primary"
                     >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="10 10 568 501"
                         width="16"
                         height="16"
-                        class="me-2"
                       >
                         <path
                           fill="currentColor"
@@ -338,7 +336,7 @@
                       target="_blank"
                       class="btn btn-outline-primary"
                     >
-                      <i class="bi bi-mastodon me-2"></i>Mastodon
+                      <i class="bi bi-mastodon me-2"></i> Mastodon
                     </a>
                   </div>
                 </div>
@@ -523,11 +521,11 @@
               <h5 class="fw-bold mb-3">Connect With Us</h5>
               <div class="d-flex gap-3">
                 <a
-                  href="https://twitter.com/haveibeenpwned"
+                  href="https://x.com/haveibeenpwned"
                   target="_blank"
                   class="text-muted hover-white fs-5"
                 >
-                  <i class="bi bi-twitter"></i>
+                  <i class="bi bi-twitter-x"></i>
                 </a>
                 <a
                   href="https://facebook.com/haveibeenpwned"

--- a/web/pages/breach.html
+++ b/web/pages/breach.html
@@ -829,11 +829,11 @@
               <h5 class="fw-bold mb-3">Connect With Us</h5>
               <div class="d-flex gap-3">
                 <a
-                  href="https://twitter.com/haveibeenpwned"
+                  href="https://x.com/haveibeenpwned"
                   target="_blank"
                   class="text-muted hover-white fs-5"
                 >
-                  <i class="bi bi-twitter"></i>
+                  <i class="bi bi-twitter-x"></i>
                 </a>
                 <a
                   href="https://facebook.com/haveibeenpwned"

--- a/web/pages/domain_search.html
+++ b/web/pages/domain_search.html
@@ -837,11 +837,11 @@
               <h5 class="fw-bold mb-3">Connect With Us</h5>
               <div class="d-flex gap-3">
                 <a
-                  href="https://twitter.com/haveibeenpwned"
+                  href="https://x.com/haveibeenpwned"
                   target="_blank"
                   class="text-muted hover-white fs-5"
                 >
-                  <i class="bi bi-twitter"></i>
+                  <i class="bi bi-twitter-x"></i>
                 </a>
                 <a
                   href="https://facebook.com/haveibeenpwned"

--- a/web/pages/faq.html
+++ b/web/pages/faq.html
@@ -1567,11 +1567,11 @@
               <h5 class="fw-bold mb-3">Connect With Us</h5>
               <div class="d-flex gap-3">
                 <a
-                  href="https://twitter.com/haveibeenpwned"
+                  href="https://x.com/haveibeenpwned"
                   target="_blank"
                   class="text-muted hover-white fs-5"
                 >
-                  <i class="bi bi-twitter"></i>
+                  <i class="bi bi-twitter-x"></i>
                 </a>
                 <a
                   href="https://facebook.com/haveibeenpwned"

--- a/web/pages/privacy.html
+++ b/web/pages/privacy.html
@@ -782,11 +782,11 @@
               <h5 class="fw-bold mb-3">Connect With Us</h5>
               <div class="d-flex gap-3">
                 <a
-                  href="https://twitter.com/haveibeenpwned"
+                  href="https://x.com/haveibeenpwned"
                   target="_blank"
                   class="text-muted hover-white fs-5"
                 >
-                  <i class="bi bi-twitter"></i>
+                  <i class="bi bi-twitter-x"></i>
                 </a>
                 <a
                   href="https://facebook.com/haveibeenpwned"

--- a/web/pages/toc.html
+++ b/web/pages/toc.html
@@ -1441,11 +1441,11 @@
                 <h5 class="fw-bold mb-3">Connect With Us</h5>
                 <div class="d-flex gap-3">
                   <a
-                    href="https://twitter.com/haveibeenpwned"
+                    href="https://x.com/haveibeenpwned"
                     target="_blank"
                     class="text-muted hover-white fs-5"
                   >
-                    <i class="bi bi-twitter"></i>
+                    <i class="bi bi-twitter-x"></i>
                   </a>
                   <a
                     href="https://facebook.com/haveibeenpwned"


### PR DESCRIPTION
- Fixing gaps on social media buttons on about page
- Using 'x' instead of twitter across all pages

<img width="568" alt="Screenshot 2025-03-24 at 22 49 09" src="https://github.com/user-attachments/assets/e412d0cd-3c7f-4204-8770-d0e7ace85790" />


Closes #44 