### PR TITLE
Fix very low color contrast on disabled inputs

### DIFF
--- a/web/assets/scss/_theme.scss
+++ b/web/assets/scss/_theme.scss
@@ -71,6 +71,8 @@ $accordion-icon-transform: rotate(-180deg);
 $input-bg: $white;
 $input-color: $grey-900;
 $input-border-color: $grey-700;
+$input-disabled-bg: #3d444c;
+$input-disabled-color: #ebebeb;
 $input-border-width: 1px;
 $input-border-radius: 16px;
 $input-padding-y: 12px;

--- a/web/assets/scss/components/_input.scss
+++ b/web/assets/scss/components/_input.scss
@@ -40,3 +40,11 @@
   font-size: var(--body-small-size);
   margin-top: 8px;
 }
+
+input:disabled {
+  cursor: not-allowed;
+
+  &::placeholder {
+    color: #ebebeb;
+  }
+}

--- a/web/examples/input.html
+++ b/web/examples/input.html
@@ -140,12 +140,21 @@
         </div>
 
         <!-- Disabled -->
-        <div class="form-group">
-          <label class="form-label">Disabled Input</label>
+        <div class="form-group my-3">
+          <label class="form-label">Placeholder</label>
           <input
             type="text"
             class="form-control"
             placeholder="Disabled input"
+            disabled
+          />
+        </div>
+        <div class="form-group my-3">
+          <label class="form-label">With value</label>
+          <input
+            type="text"
+            class="form-control"
+            value="Disabled input"
             disabled
           />
         </div>


### PR DESCRIPTION
Made the background color and the color lighter, which passes the APCA. But, to be honest, I'm not that keen on this, I think it presents more of a usability issue now since it's not clear that these inputs are disabled. The "not-allowed" cursor does help somewhat, but the visual indication by just looking at it doesn't give me the feeling that this is a disabled input. 

@troyhunt What do you think?

<img width="943" alt="Screenshot 2025-04-02 at 23 00 03" src="https://github.com/user-attachments/assets/2042ed47-9e77-4294-8ce8-dab139d9a753" />

<img width="748" alt="Screenshot 2025-04-02 at 23 01 09" src="https://github.com/user-attachments/assets/ef0d2bb3-9545-43da-814a-bc57eef6609a" />

<img width="694" alt="Screenshot 2025-04-02 at 23 03 18" src="https://github.com/user-attachments/assets/b6de1d25-728a-4cae-9f66-d9e16a360ff5" />

Closes #32 

