### PR TITLE
Displaying Sign In in the action button in navbar when not authenticated, otherwise it says Dashboard

### DIFF
--- a/web/assets/scss/pages/dashboard_internal.scss
+++ b/web/assets/scss/pages/dashboard_internal.scss
@@ -392,3 +392,26 @@
 #subscription {
   position: relative;
 }
+
+#userEmail {
+  max-width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  color: white; /* Ensure text is visible */
+}
+
+/* Adjust avatar-circle for icon */
+.avatar-circle {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.avatar-circle .bi-person-fill {
+  font-size: 1.5rem;
+}

--- a/web/pages/about.html
+++ b/web/pages/about.html
@@ -33,7 +33,7 @@
           <img src="../assets/images/hibp-logo.svg" alt="Have I Been Pwned" height="30" />
         </a>
         <div class="d-flex align-items-center justify-content-end gap-2">
-          <a href="dashboard.html" class="btn btn-secondary btn-sm d-lg-none" role="button">Dashboard</a>
+          <a href="dashboard.html" class="btn btn-secondary btn-sm d-lg-none" role="button">Sign in</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
             <span class="navbar-toggler-icon"></span>
           </button>
@@ -78,7 +78,7 @@
             </li>
           </ul>
         </div>
-        <a href="dashboard.html" class="btn btn-secondary d-none d-lg-inline-flex" role="button"> Dashboard </a>
+        <a href="dashboard.html" class="btn btn-secondary d-none d-lg-inline-flex" role="button"> Sign in </a>
       </div>
     </nav>
 

--- a/web/pages/dashboard.html
+++ b/web/pages/dashboard.html
@@ -35,7 +35,7 @@
           <img src="../assets/images/hibp-logo.svg" alt="Have I Been Pwned" height="30" />
         </a>
         <div class="d-flex align-items-center justify-content-end gap-2">
-          <a href="dashboard.html" class="btn btn-secondary btn-sm d-lg-none active" role="button">Dashboard</a>
+          <a href="dashboard.html" class="btn btn-secondary btn-sm d-lg-none active" role="button">Sign in</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
             <span class="navbar-toggler-icon"></span>
           </button>
@@ -80,7 +80,7 @@
             </li>
           </ul>
         </div>
-        <a href="dashboard.html" class="btn btn-secondary d-none d-lg-inline-flex" role="button"> Dashboard </a>
+        <a href="dashboard.html" class="btn btn-secondary d-none d-lg-inline-flex" role="button"> Sign in </a>
       </div>
     </nav>
 

--- a/web/pages/dashboard_internal.html
+++ b/web/pages/dashboard_internal.html
@@ -81,7 +81,7 @@
             </li>
           </ul>
         </div>
-        <a href="dashboard.html" class="btn btn-secondary d-none d-lg-inline-flex" role="button"> Dashboard </a>
+        <a href="dashboard.html" class="btn btn-secondary d-none d-lg-inline-flex" role="button">Dashboard</a>
       </div>
     </nav>
 
@@ -94,12 +94,12 @@
               <div class="card card-glow mb-4">
                 <div class="card-body p-4">
                   <div class="d-flex align-items-center mb-4">
-                    <div class="avatar-circle me-3 bg-primary" id="userInitial">
-                      <!-- Will be filled by JS -->
+                    <div class="avatar-circle me-3 bg-primary-transparent" id="userInitial">
+                      <i class="bi bi-person-fill text-primary"></i>
                     </div>
                     <div>
-                      <div class="text-truncate" id="userEmail">
-                        <!-- Will be filled by JS -->
+                      <div id="userEmail" data-bs-toggle="tooltip" data-bs-placement="bottom" title="very.long.email.address.that.needs.truncation@example.com">
+                        very.long.email.address.that.needs.truncation@example.com
                       </div>
                       <div class="text-muted small">Free Account</div>
                     </div>
@@ -2209,6 +2209,17 @@
           if (this.classList.contains("is-invalid")) {
             this.classList.remove("is-invalid");
           }
+        });
+      });
+    </script>
+
+    <!-- Initialize tooltips and handle email display -->
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        // Initialize tooltips
+        var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+        var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+          return new bootstrap.Tooltip(tooltipTriggerEl);
         });
       });
     </script>

--- a/web/pages/passwords.html
+++ b/web/pages/passwords.html
@@ -38,7 +38,7 @@
           <img src="../assets/images/hibp-logo.svg" alt="Have I Been Pwned" height="30" />
         </a>
         <div class="d-flex align-items-center justify-content-end gap-2">
-          <a href="dashboard.html" class="btn btn-secondary btn-sm d-lg-none" role="button">Dashboard</a>
+          <a href="dashboard.html" class="btn btn-secondary btn-sm d-lg-none" role="button">Sign in</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
             <span class="navbar-toggler-icon"></span>
           </button>
@@ -83,7 +83,7 @@
             </li>
           </ul>
         </div>
-        <a href="dashboard.html" class="btn btn-secondary d-none d-lg-inline-flex" role="button"> Dashboard </a>
+        <a href="dashboard.html" class="btn btn-secondary d-none d-lg-inline-flex" role="button"> Sign in </a>
       </div>
     </nav>
 

--- a/web/pages/pwned_websites.html
+++ b/web/pages/pwned_websites.html
@@ -33,7 +33,7 @@
           <img src="../assets/images/hibp-logo.svg" alt="Have I Been Pwned" height="30" />
         </a>
         <div class="d-flex align-items-center justify-content-end gap-2">
-          <a href="dashboard.html" class="btn btn-secondary btn-sm d-lg-none" role="button">Dashboard</a>
+          <a href="dashboard.html" class="btn btn-secondary btn-sm d-lg-none" role="button">Sign in</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
             <span class="navbar-toggler-icon"></span>
           </button>
@@ -78,7 +78,7 @@
             </li>
           </ul>
         </div>
-        <a href="dashboard.html" class="btn btn-secondary d-none d-lg-inline-flex" role="button"> Dashboard </a>
+        <a href="dashboard.html" class="btn btn-secondary d-none d-lg-inline-flex" role="button"> Sign in </a>
       </div>
     </nav>
 
@@ -1955,7 +1955,7 @@
                         </div>
                       </td>
                       <td data-name="pwncount" data-value="1594305">1,594,305</td>
-                      <td data-name="date" data-value="1711852455000">Mar 2024</td>
+                      <td data-name="date" data-value="1711852455000">Apr 2024</td>
                       <td>
                         <a href="breach.html" class="btn btn-secondary d-flex align-items-center justify-content-center table-action-btn">
                           <i class="bi bi-arrow-right"></i>


### PR DESCRIPTION
- Replacing user initials with a profile icon
- Using "Sign in" for action button when not authenticated, "Dashboard" when user is authenticated
- Email is truncated and full email displayed in a tooltip

<img width="1419" alt="Screenshot 2025-05-14 at 00 31 09" src="https://github.com/user-attachments/assets/855d97e9-3d68-49da-a07d-b650c98fea38" />
<img width="1365" alt="Screenshot 2025-05-14 at 00 31 20" src="https://github.com/user-attachments/assets/51606a2a-175b-4e49-b831-8204ec9d428b" />

Closes #150 